### PR TITLE
Handle negative sensor values

### DIFF
--- a/Arduino/v3/SensactArduinoCode/IO.cpp
+++ b/Arduino/v3/SensactArduinoCode/IO.cpp
@@ -17,6 +17,7 @@ int InputStream::getChar() {
 }
 
 long InputStream::_getNumber(int nbytes) {
+  boolean negative = false;
   long val = 0;
   int i, ch;
   
@@ -26,6 +27,17 @@ long InputStream::_getNumber(int nbytes) {
       return IO_ERROR;
     }
     val = (val << 4) + ch;
+    if ( (i == 0) && (ch & 0x8) ) {
+      negative = true;
+    }
+  }
+  
+  if (negative) {
+    if (nbytes == 4) {
+      val = val - 0x10000L;
+    } else {
+      return IO_ERROR;
+    }
   }
   return val;
 }

--- a/Arduino/v3/SensactArduinoCode/IO.h
+++ b/Arduino/v3/SensactArduinoCode/IO.h
@@ -12,7 +12,7 @@
  * Code to get and put various data types from/to a stream.
  * The types are:
  *  char  - a char
- *  num   - a 2 byte (4 nibble) number
+ *  num   - a 2 byte (4 nibble) number (may be negative)
  *  long  - a 4 byte (8 nibble) number
  *  ID    - a 1 byte (2 nibble) value
  *  State - a 1 byte (1 nibble) value
@@ -22,7 +22,10 @@
  *  Two stream types are supported: Serial and EEPROM
  */
 
-#define IO_ERROR -1
+// getNum() can return 2-byte negative numbers, so IO_ERROR 
+// needs to be a negative value that cannot fit in 2 bytes.
+#define IO_ERROR -66000
+
 class InputStream {
   public:
     virtual void init() = 0;

--- a/Config/v3/configSensactApp/serial.js
+++ b/Config/v3/configSensactApp/serial.js
@@ -202,7 +202,9 @@ var inputStream = {
 		return tmp;
 	},
 	
+	// Note: 2-byte values may be negative.
 	getNum: function(count) {
+		var negative = false;
 		var value = 0;
 		for(var i=0; i< count; i++) {
 			var tmp = this.getChar().charCodeAt(0) - NUMBER_MASK;
@@ -210,6 +212,19 @@ var inputStream = {
 				throw "Invalid Number";
 			}
 			value = (value << 4) + tmp;
+			if ((i == 0) && (tmp & 0x8)) {
+				// High order bit is set.  This is a negative number.
+				negative = true;
+			}
+		}
+		
+		if (negative) {
+			if (count == 4) { // 4 nibbles - two bytes
+				// We will have a fairly large positive number at this point.
+				value = value - 0x10000;
+			} else {
+				throw "Large negative numbers are not supported";
+			}
 		}
 		return value;
 	},

--- a/Config/v3/configSensactApp/triggers.js
+++ b/Config/v3/configSensactApp/triggers.js
@@ -62,8 +62,8 @@ function createSensorList() {
 	sensors.push( new Sensor(1, "Input 1", 0, 1023, true) );
 	sensors.push( new Sensor(2, "Input 2", 0, 1023, true) );
 	sensors.push( new Sensor(3, "Keyboard", 0, 255, false) );
-	sensors.push( new Sensor(4, "Joystick-X", 0, 100, true) );
-	sensors.push( new Sensor(5, "Joystick-Y", 0, 100, true) );
+	sensors.push( new Sensor(4, "Joystick-X", -100, 100, true) );
+	sensors.push( new Sensor(5, "Joystick-Y", -100, 100, true) );
 }
 
 function getSensorByID(id) {


### PR DESCRIPTION
This change allows 2-byte values (in particular sensor values) to be
negative numbers.  Values in triggers and in sensor reports can now be
negative.